### PR TITLE
feat(connectors): implement RetryPolicy with exponential backoff and …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,7 +134,8 @@ lazy val connectors = project
         Dependencies.delta ++
         Dependencies.config ++
         Dependencies.logging ++
-        Dependencies.test
+        Dependencies.test ++
+        Dependencies.jdbc
   )
 
 // ---------------------------------------------------------------------------

--- a/connectors/src/main/scala/com/criticalinfra/connectors/RetryPolicy.scala
+++ b/connectors/src/main/scala/com/criticalinfra/connectors/RetryPolicy.scala
@@ -1,0 +1,96 @@
+package com.criticalinfra.connectors
+
+import com.criticalinfra.engine.ConnectorError
+
+import scala.annotation.tailrec
+
+// =============================================================================
+// RetryPolicy — exponential-backoff retry utility for source connectors
+//
+// All JDBC and file connectors delegate transient-failure retries to this
+// object rather than implementing ad-hoc retry loops.  The delay function is
+// injectable so that unit tests never call Thread.sleep.
+// =============================================================================
+
+/** Stateless retry utility with configurable exponential backoff.
+  *
+  * Each connector that can encounter transient failures (e.g. network blips on a JDBC connection,
+  * temporary file-system unavailability) should route those failures through [[RetryPolicy.retry]]
+  * rather than implementing a bespoke retry loop.
+  *
+  * ==Backoff schedule==
+  * {{{
+  *   Attempt 1 : no delay          (first try)
+  *   Attempt 2 : 100 ms            (baseDelayMs * 2^0)
+  *   Attempt 3 : 200 ms            (baseDelayMs * 2^1)
+  *   Attempt 4 : 400 ms            (baseDelayMs * 2^2)
+  *   Attempt N : 100 * 2^(N-2) ms
+  * }}}
+  *
+  * ==Error handling==
+  * If all attempts are exhausted the last [[ConnectorError]] received is returned as-is. No
+  * exceptions are thrown and no errors are swallowed.
+  */
+object RetryPolicy {
+
+  /** Base delay in milliseconds applied before the first retry (second attempt). */
+  private val baseDelayMs: Long = 100L
+
+  /** Retry `attempt` up to `maxAttempts` times with exponential backoff between retries.
+    *
+    * @param attempt
+    *   By-name expression that produces either a successful result or a [[ConnectorError]]. It is
+    *   re-evaluated on every attempt so that side-effectful operations (e.g. opening a JDBC
+    *   connection) are retried correctly.
+    * @param maxAttempts
+    *   Total number of times `attempt` will be evaluated. Must be >= 1; passing 0 or a negative
+    *   value returns `Left(ConnectorError("RetryPolicy", "maxAttempts must be >= 1"))` immediately.
+    * @param delayFn
+    *   Function that receives the delay in milliseconds and performs the actual sleep. Defaults to
+    *   [[Thread.sleep]]. Inject a no-op (`_ => ()`) in unit tests to avoid real delays.
+    * @tparam A
+    *   Type of the successful result.
+    * @return
+    *   `Right(a)` on the first successful attempt, or the last `Left(ConnectorError)` if every
+    *   attempt fails.
+    */
+  def retry[A](
+      attempt: => Either[ConnectorError, A],
+      maxAttempts: Int,
+      delayFn: Long => Unit = Thread.sleep
+  ): Either[ConnectorError, A] =
+    if (maxAttempts <= 0)
+      Left(ConnectorError("RetryPolicy", "maxAttempts must be >= 1"))
+    else
+      loop(attempt, maxAttempts, attemptNumber = 1, delayFn)
+
+  /** Tail-recursive inner loop that tracks the current attempt number.
+    *
+    * @param attempt
+    *   By-name expression re-evaluated each call.
+    * @param remaining
+    *   Number of attempts still permitted (counts down to 0).
+    * @param attemptNumber
+    *   1-based index of the current attempt, used to compute the backoff delay.
+    * @param delayFn
+    *   Injectable sleep function.
+    */
+  @tailrec
+  private def loop[A](
+      attempt: => Either[ConnectorError, A],
+      remaining: Int,
+      attemptNumber: Int,
+      delayFn: Long => Unit
+  ): Either[ConnectorError, A] = {
+    val result = attempt
+    result match {
+      case Right(_)                  => result
+      case Left(_) if remaining <= 1 => result
+      case Left(_)                   =>
+        // Apply delay before the next attempt: baseDelayMs * 2^(attemptNumber - 1)
+        val delayMs = baseDelayMs * math.pow(2, attemptNumber - 1).toLong
+        delayFn(delayMs)
+        loop(attempt, remaining - 1, attemptNumber + 1, delayFn)
+    }
+  }
+}

--- a/connectors/src/test/scala/com/criticalinfra/connectors/RetryPolicySpec.scala
+++ b/connectors/src/test/scala/com/criticalinfra/connectors/RetryPolicySpec.scala
@@ -1,0 +1,172 @@
+package com.criticalinfra.connectors
+
+import scala.collection.mutable.ListBuffer
+
+import com.criticalinfra.engine.ConnectorError
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+// =============================================================================
+// RetryPolicySpec — unit tests for RetryPolicy
+//
+// All tests inject a no-op or spy delayFn so that Thread.sleep is never called.
+// ListBuffer spies record the exact millisecond values passed to the delay
+// function, allowing precise assertions about the exponential backoff schedule.
+// =============================================================================
+
+class RetryPolicySpec extends AnyFlatSpec with Matchers {
+
+  // ---------------------------------------------------------------------------
+  // Helper factories
+  // ---------------------------------------------------------------------------
+
+  /** A spy delay function that records every delay value it receives. */
+  private def spyDelay(): (ListBuffer[Long], Long => Unit) = {
+    val recorded = ListBuffer.empty[Long]
+    val fn: Long => Unit = ms => recorded += ms
+    (recorded, fn)
+  }
+
+  /** A no-op delay function — never records anything. */
+  private val noDelay: Long => Unit = _ => ()
+
+  private val testError: ConnectorError = ConnectorError("test-source", "transient failure")
+
+  // ---------------------------------------------------------------------------
+  // 1. Returns Right immediately when first attempt succeeds (no delays called)
+  // ---------------------------------------------------------------------------
+
+  "RetryPolicy.retry" should "return Right immediately when the first attempt succeeds" in {
+    val (delays, spy) = spyDelay()
+
+    val result = RetryPolicy.retry(Right("ok"), maxAttempts = 3, delayFn = spy)
+
+    result shouldBe Right("ok")
+    delays shouldBe empty
+  }
+
+  // ---------------------------------------------------------------------------
+  // 2. Retries after a Left and returns Right on the second attempt
+  // ---------------------------------------------------------------------------
+
+  it should "retry after a Left and return Right on the second attempt" in {
+    val (delays, spy) = spyDelay()
+    var callCount     = 0
+
+    val result = RetryPolicy.retry(
+      {
+        callCount += 1
+        if (callCount >= 2) Right("recovered") else Left(testError)
+      },
+      maxAttempts = 3,
+      delayFn = spy
+    )
+
+    result shouldBe Right("recovered")
+    callCount shouldBe 2
+    // One delay between attempt 1 and attempt 2
+    delays.length shouldBe 1
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3. Exhausts all retries and returns the last Left when every attempt fails
+  // ---------------------------------------------------------------------------
+
+  it should "exhaust all retries and return the last Left when every attempt fails" in {
+    val lastError = ConnectorError("test-source", "persistent failure")
+    var callCount = 0
+
+    val result = RetryPolicy.retry(
+      {
+        callCount += 1
+        Left(lastError)
+      },
+      maxAttempts = 3,
+      delayFn = noDelay
+    )
+
+    result shouldBe Left(lastError)
+    callCount shouldBe 3
+  }
+
+  // ---------------------------------------------------------------------------
+  // 4. Delay function is called the correct number of times
+  // ---------------------------------------------------------------------------
+
+  it should "call the delay function exactly (maxAttempts - 1) times when all attempts fail" in {
+    val (delays, spy) = spyDelay()
+
+    RetryPolicy.retry(Left(testError), maxAttempts = 4, delayFn = spy)
+
+    // 4 attempts → 3 delays (before attempts 2, 3, and 4)
+    delays.length shouldBe 3
+  }
+
+  // ---------------------------------------------------------------------------
+  // 5. Delay values follow the exponential backoff sequence
+  // ---------------------------------------------------------------------------
+
+  it should "pass delay values following the exponential sequence 100, 200, 400 ms" in {
+    val (delays, spy) = spyDelay()
+
+    RetryPolicy.retry(Left(testError), maxAttempts = 4, delayFn = spy)
+
+    delays.toList shouldBe List(100L, 200L, 400L)
+  }
+
+  // ---------------------------------------------------------------------------
+  // 6. Returns Left(ConnectorError) immediately when maxAttempts = 0 or negative
+  // ---------------------------------------------------------------------------
+
+  it should "return Left(ConnectorError) immediately when maxAttempts is 0" in {
+    val (delays, spy) = spyDelay()
+
+    val result = RetryPolicy.retry(Right("never reached"), maxAttempts = 0, delayFn = spy)
+
+    result shouldBe Left(ConnectorError("RetryPolicy", "maxAttempts must be >= 1"))
+    delays shouldBe empty
+  }
+
+  it should "return Left(ConnectorError) immediately when maxAttempts is negative" in {
+    val (delays, spy) = spyDelay()
+
+    val result = RetryPolicy.retry(Right("never reached"), maxAttempts = -5, delayFn = spy)
+
+    result shouldBe Left(ConnectorError("RetryPolicy", "maxAttempts must be >= 1"))
+    delays shouldBe empty
+  }
+
+  // ---------------------------------------------------------------------------
+  // 7. maxAttempts = 1 — returns Left without calling delay when the single attempt fails
+  // ---------------------------------------------------------------------------
+
+  it should "return Left without calling delay when maxAttempts = 1 and the attempt fails" in {
+    val (delays, spy) = spyDelay()
+
+    val result = RetryPolicy.retry(Left(testError), maxAttempts = 1, delayFn = spy)
+
+    result shouldBe Left(testError)
+    delays shouldBe empty
+  }
+
+  // ---------------------------------------------------------------------------
+  // 8. Returns Right on the last allowed attempt (boundary case)
+  // ---------------------------------------------------------------------------
+
+  it should "return Right on the last allowed attempt" in {
+    val maxAttempts = 5
+    var callCount   = 0
+
+    val result = RetryPolicy.retry(
+      {
+        callCount += 1
+        if (callCount >= maxAttempts) Right("success-on-last") else Left(testError)
+      },
+      maxAttempts = maxAttempts,
+      delayFn = noDelay
+    )
+
+    result shouldBe Right("success-on-last")
+    callCount shouldBe maxAttempts
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -140,6 +140,17 @@ object Dependencies {
   )
 
   // ---------------------------------------------------------------------------
+  // JDBC test utilities — in-process database for connector unit tests
+  // ---------------------------------------------------------------------------
+
+  /** H2 in-process JDBC database — used in connector unit tests to exercise JDBC logic without
+    * requiring a running external database instance.
+    */
+  val h2: ModuleID = "com.h2database" % "h2" % "2.2.224" % Test
+
+  val jdbc: Seq[ModuleID] = Seq(h2)
+
+  // ---------------------------------------------------------------------------
   // AWS SDK v2 — Secrets Manager client (production scope; not test-only)
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
…unit tests

Introduces the RetryPolicy utility object as the first production code in the connectors module. Provides a tail-recursive, @tailrec-annotated retry loop with injectable delay for deterministic testing, and adds the H2 test dependency to support upcoming JDBC connector unit tests.